### PR TITLE
fix: defer first `hatch` call so it can’t prevent activation

### DIFF
--- a/.knip.jsonc
+++ b/.knip.jsonc
@@ -1,6 +1,6 @@
 {
 	"$schema": "https://unpkg.com/knip@6/schema-jsonc.json",
-	"entry": ["src/extension.ts", "*.ts", ".*.mjs", "src/test/**/*.test.ts"],
+	"entry": ["*.ts", ".*.mjs", "test/**/*.test.ts"],
 	"ignore": [".yarn/**/*"],
 	"ignoreDependencies": [
 		"@secretlint/*", // https://github.com/microsoft/vscode-vsce/issues/1156

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -6,6 +6,7 @@
 .yarn/**
 assets/*.fig
 src/**
+test/**
 .gitignore
 *.yaml
 *.yml

--- a/biome.jsonc
+++ b/biome.jsonc
@@ -1,5 +1,5 @@
 {
-	"$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
+	"$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
 	"vcs": {
 		"enabled": true,
 		"clientKind": "git",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -9,6 +9,7 @@ import {
 } from 'vscode'
 import which from 'which'
 import { EXE_CONFIG_SECTION, EXE_CONFIG_SETTING } from '../common/constants.js'
+import { createDeferred, type Deferred } from '../common/deferred.js'
 import { traceError } from '../common/logging.js'
 import execFile, { type ExecFile } from './exec-file.js'
 import type { CreateEnvOptions, HatchEnvInfo } from './hatch.js'
@@ -46,42 +47,27 @@ function suggestExeConfig<
 }
 
 export class HatchExecutableTracker {
-	#executable: string
+	#executable: Deferred<string>
 	#configChangeListener: Disposable
-	private constructor(
-		executable: string,
+	constructor(
 		readonly log: LogOutputChannel,
 		public exec: ExecFile = execFile,
 	) {
-		this.#executable = executable
+		this.#executable = createDeferred()
 		this.#configChangeListener = workspace.onDidChangeConfiguration((e) =>
 			this.#handleConfigChange(e),
 		)
 	}
 
-	static async create(
-		log: LogOutputChannel,
-		exec?: ExecFile | undefined,
-	): Promise<HatchExecutableTracker> {
-		const executable = await getHatch()
-		return new HatchExecutableTracker(executable, log, exec)
-	}
-
-	get executable(): string {
-		return this.#executable
-	}
-
-	get #hatch(): Hatch {
-		return new Hatch(this.#executable, this.exec)
-	}
-
-	get #inst(): Installer {
-		return new Installer(this.#executable, this.exec)
+	async #initialize(): Promise<void> {
+		if (!this.#executable.completed) {
+			this.#executable.resolve(await getHatch())
+		}
 	}
 
 	async #handleConfigChange(e: ConfigurationChangeEvent): Promise<void> {
 		if (e.affectsConfiguration(EXE_CONFIG_KEY)) {
-			this.#executable = await getHatch()
+			this.#executable.resolve(await getHatch())
 		}
 	}
 
@@ -89,40 +75,55 @@ export class HatchExecutableTracker {
 		this.#configChangeListener.dispose()
 	}
 
-	@suggestExeConfig
-	getEnvs(projectPath: string): Promise<HatchEnvInfo[]> {
-		return this.#hatch.getEnvs(projectPath)
+	get executable(): Promise<string> {
+		return this.#initialize().then(() => this.#executable.promise)
 	}
-	@suggestExeConfig
-	findEnv(env: HatchEnvInfo): Promise<string> {
-		return this.#hatch.findEnv(env)
+
+	get #hatch(): Promise<Hatch> {
+		return this.executable.then((e) => new Hatch(e, this.exec))
 	}
-	@suggestExeConfig
-	removeEnv(env: HatchEnvInfo): Promise<void> {
-		return this.#hatch.removeEnv(env)
-	}
-	@suggestExeConfig
-	createEnv(env: HatchEnvInfo, opts?: CreateEnvOptions): Promise<void> {
-		return this.#hatch.createEnv(env, opts)
+
+	get #inst(): Promise<Installer> {
+		return this.executable.then((e) => new Installer(e, this.exec))
 	}
 
 	@suggestExeConfig
-	listPackages(
-		env: HatchEnvInfo,
-	): Promise<{ name: string; version: string }[]> {
-		return this.#inst.listPackages(env)
+	async getEnvs(projectPath: string): Promise<HatchEnvInfo[]> {
+		return (await this.#hatch).getEnvs(projectPath)
 	}
 	@suggestExeConfig
-	installPackages(
+	async findEnv(env: HatchEnvInfo): Promise<string> {
+		return (await this.#hatch).findEnv(env)
+	}
+	@suggestExeConfig
+	async removeEnv(env: HatchEnvInfo): Promise<void> {
+		return (await this.#hatch).removeEnv(env)
+	}
+	@suggestExeConfig
+	async createEnv(env: HatchEnvInfo, opts?: CreateEnvOptions): Promise<void> {
+		return (await this.#hatch).createEnv(env, opts)
+	}
+
+	@suggestExeConfig
+	async listPackages(
+		env: HatchEnvInfo,
+	): Promise<{ name: string; version: string }[]> {
+		return (await this.#inst).listPackages(env)
+	}
+	@suggestExeConfig
+	async installPackages(
 		env: HatchEnvInfo,
 		packages: string[],
 		opts: InstallOptions = {},
 	): Promise<void> {
-		return this.#inst.installPackages(env, packages, opts)
+		return (await this.#inst).installPackages(env, packages, opts)
 	}
 	@suggestExeConfig
-	uninstallPackages(env: HatchEnvInfo, packages: string[]): Promise<void> {
-		return this.#inst.uninstallPackages(env, packages)
+	async uninstallPackages(
+		env: HatchEnvInfo,
+		packages: string[],
+	): Promise<void> {
+		return (await this.#inst).uninstallPackages(env, packages)
 	}
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,10 +16,8 @@ export async function activate(context: ExtensionContext): Promise<Api> {
 	const log = window.createOutputChannel('Hatch', { log: true })
 	context.subscriptions.push(log, registerLogger(log))
 
-	const [exe, api] = await Promise.all([
-		HatchExecutableTracker.create(log),
-		getEnvExtApi(),
-	])
+	const exe = new HatchExecutableTracker(log)
+	const api = await getEnvExtApi()
 	setWorkspacePersistentState(context)
 	const envManager = new HatchEnvManager(api, exe, log)
 	const pkgManager = new HatchPackageManager(api, exe, log)

--- a/src/hatch-env-manager.ts
+++ b/src/hatch-env-manager.ts
@@ -338,26 +338,22 @@ export class HatchEnvManager implements EnvironmentManager {
 	}
 
 	async #getHatchEnvs(projectPath: string): Promise<HatchEnvironment[]> {
+		const hatchExe = await this.#hatch.executable
 		const envs = await this.#hatch.getEnvs(projectPath)
-		return envs.map((e) => this.#hatch2pythonEnv(e))
+		return envs.map((e) => this.#hatch2pythonEnv(hatchExe, e))
 	}
 
-	#hatch2pythonEnv({
-		name,
-		path,
-		conf,
-		projectPath,
-	}: HatchEnvInfo): HatchEnvironment {
+	#hatch2pythonEnv(
+		executable: string,
+		{ name, path, conf, projectPath }: HatchEnvInfo,
+	): HatchEnvironment {
 		const shellActivation: Map<string, PythonCommandRunConfiguration[]> =
 			new Map()
 		const shellDeactivation: Map<string, PythonCommandRunConfiguration[]> =
 			new Map()
 
 		shellActivation.set('unknown', [
-			{
-				executable: this.#hatch.executable,
-				args: [`--env=${name}`, 'shell'],
-			},
+			{ executable, args: [`--env=${name}`, 'shell'] },
 		])
 		shellDeactivation.set('unknown', [{ executable: 'exit' }])
 

--- a/test/workspace/.vscode/settings.json
+++ b/test/workspace/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-	"hatch.executable": "IDoNotExistButWeReplaceExecFile"
+	"hatch.executable": "IDoNotExistButWeReplaceExecFile",
 }


### PR DESCRIPTION
Originally made to address #160, but I only see 89ms -> 81ms, so the speedup wouldn’t be worth the more complicated code.

This will however allow the extension to be activated when no hatch binary is found, so this part _is_ worth it.