### PR TITLE
fix: make hatch.envInterpreter enablement a valid when-clause

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
 			{
 				"command": "hatch.envInterpreter",
 				"title": "Hatch: Get an environment’s interpreter path",
-				"enablement": false
+				"enablement": "false"
 			}
 		],
 		"icons": {


### PR DESCRIPTION
Fixes #194.

### Problem

`hatch.envInterpreter` was contributed with `"enablement": false` — a **boolean**. Per the [contribution-points reference](https://code.visualstudio.com/api/references/contribution-points#contributes.commands), a command's `enablement` is a [`when` clause](https://code.visualstudio.com/api/references/when-clause-contexts), i.e. a **string** context-key expression (the `commandType` schema in `menusExtensionPoint.ts` declares it as `type: 'string'`).

VS Code passes the value straight to `ContextKeyExpr.deserialize`, whose scanner calls `charCodeAt` on it. A boolean has no `charCodeAt`, so it throws a `TypeError` that aborts the `commands` extension-point handler **mid-iteration**. Every extension whose commands are registered after Hatch then loses its command registration: those commands disappear from the Command Palette, and VS Code logs `Menu item references a command ... which is not defined in the 'commands' section.` for each of their menu items.

The effect is order-dependent and platform-independent (reproduced on Linux and Windows, on VS Code stable and Insiders).

### Fix

Make `enablement` a valid `when`-clause expression by using the string `"false"` instead of the boolean:

```json
"commands": [
  {
    "command": "hatch.envInterpreter",
    "title": "Hatch: Get an environment’s interpreter path",
    "enablement": "false"
  }
]
```

`hatch.envInterpreter` is only invoked programmatically via `executeCommand` (see `src/extension.ts`), so it never needs a UI affordance. `enablement: "false"`:

- fixes the crash (a string deserializes fine),
- hides the command from the Command Palette (the palette filters out disabled commands), and
- disables it across **all menus and keybindings** — broader than a `commandPalette` `when` clause, which only covers the palette.

`executeCommand` bypasses enablement, so the command stays fully usable programmatically. `biome check` passes.
