### PR TITLE
fix: prepend PowerShell call operator when activating environments

### DIFF
--- a/src/hatch-env-manager.ts
+++ b/src/hatch-env-manager.ts
@@ -352,8 +352,13 @@ export class HatchEnvManager implements EnvironmentManager {
 		const shellDeactivation: Map<string, PythonCommandRunConfiguration[]> =
 			new Map()
 
-		shellActivation.set('unknown', [
-			{ executable, args: [`--env=${name}`, 'shell'] },
+		const args = ['--env', name, 'shell']
+		shellActivation.set('unknown', [{ executable, args }])
+		// PowerShell parses a leading quoted string as an expression, so a quoted
+		// executable path (e.g. under "C:\Program Files") must be invoked with the
+		// call operator `&`. A lone `&` is left unquoted by the host's quoting.
+		shellActivation.set('pwsh', [
+			{ executable: '&', args: [executable, ...args] },
 		])
 		shellDeactivation.set('unknown', [{ executable: 'exit' }])
 


### PR DESCRIPTION
Fixes #196.

### Problem

Activating a Hatch environment in a **PowerShell** terminal fails with a `ParserError` when the Hatch executable path contains a space (e.g. the standalone installer's `C:\Program Files\Hatch\hatch.EXE`). The host quotes the executable, and PowerShell parses a leading quoted string as an *expression* rather than a command to run:

```
"C:\Program Files\Hatch\hatch.EXE" --env=devel.py3.14-rf74 shell
ParserError: Unexpected token 'env=devel.py3.14-rf74' in expression or statement.
```

Invoking a quoted executable in PowerShell requires the call operator `&`. The `ms-python.vscode-python-envs` host adds it automatically on its *run* path (`runInTerminal.ts`) but **not** on the *activation* path (`getShellCommandAsString`), so the manager has to supply it for PowerShell — which the built-in venv/poetry managers do, but this manager did not.

### Fix

Add a `pwsh`-specific `shellActivation` entry that prefixes the call operator, matching the built-in managers (`{ executable: '&', args: [...] }`). A lone `&` is left unquoted by the host's quoting, producing:

```
& "C:\Program Files\Hatch\hatch.EXE" --env devel.py3.14-rf74 shell
```

`'pwsh'` covers both Windows PowerShell 5.x and PowerShell 7; cmd/bash/zsh/fish keep using the shared `'unknown'` entry, where `&` is neither needed nor valid. The `--env` flag and its value are now passed as separate args so only the value is quoted when needed.

### Testing

Verified manually on Windows with PowerShell — activation now works. `tsc --noEmit` and `biome check` pass.
