### PR TITLE
ci: add release-please token

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,4 +15,4 @@ jobs:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           release-type: node
-          token: ${{ secrets.GH_CONTENT_TOKEN }}GH_CONTENT_TOKEN
+          token: ${{ secrets.GH_CONTENT_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,3 +15,4 @@ jobs:
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
           release-type: node
+          token: ${{ secrets.GH_CONTENT_TOKEN }}GH_CONTENT_TOKEN


### PR DESCRIPTION
Use token for release-please so GH workflows run when the release-please workflow makes PRs or releases